### PR TITLE
Issue #48 documentation coverage

### DIFF
--- a/Corkboard/Controllers/BaseController.cs
+++ b/Corkboard/Controllers/BaseController.cs
@@ -33,6 +33,14 @@ public abstract class BaseController : Controller
 	protected string? CurrentUserId => _currentUserId ??= _userManager.GetUserId(User);
 	private string? _currentUserId;
 
+	/// <summary>
+	/// Gets the current user's role within the specified server.
+	/// </summary>
+	/// <param name="serverId">The server ID to evaluate membership for.</param>
+	/// <returns>
+	/// The user's <see cref="RoleType"/> if they are a member; otherwise <c>null</c>.
+	/// Returns <c>null</c> if the user is not authenticated.
+	/// </returns>
 	protected async Task<RoleType?> GetUserRoleInServerAsync(int serverId)
 	{
 		if (CurrentUserId == null) return null;
@@ -42,12 +50,22 @@ public abstract class BaseController : Controller
 		return member?.Role;
 	}
 
+	/// <summary>
+	/// Determines whether the current user is a moderator or owner of the specified server.
+	/// </summary>
+	/// <param name="serverId">The server ID to check authorization against.</param>
+	/// <returns><c>true</c> if the user is a moderator or owner; otherwise <c>false</c>.</returns>
 	protected async Task<bool> IsUserModeratorOrOwnerAsync(int serverId)
 	{
 		RoleType? role = await GetUserRoleInServerAsync(serverId);
 		return role == RoleType.Moderator || role == RoleType.Owner;
 	}
 
+	/// <summary>
+	/// Determines whether the current user is the owner of the specified server.
+	/// </summary>
+	/// <param name="serverId">The server ID to check ownership for.</param>
+	/// <returns><c>true</c> if the user is the server owner; otherwise <c>false</c>.</returns>
 	protected async Task<bool> IsUserOwnerAsync(int serverId)
 	{
 		RoleType? role = await GetUserRoleInServerAsync(serverId);

--- a/Corkboard/Controllers/InvitesController.cs
+++ b/Corkboard/Controllers/InvitesController.cs
@@ -46,6 +46,15 @@ public class InvitesController : BaseController
 		return RedirectToAction(nameof(Redeem), new { code = inviteCode });
 	}
 
+	/// <summary>
+	/// Displays invite details for a specific invite code and indicates membership status.
+	/// GET /Invites/Redeem/{code}
+	/// </summary>
+	/// <param name="code">The invite code to validate and redeem.</param>
+	/// <returns>
+	/// The invite view when valid; <see cref="NotFound()"/> if invalid or for another user.
+	/// Sets <c>ViewBag.AlreadyMember</c> when the user is already a member.
+	/// </returns>
 	[HttpGet("/Invites/Redeem/{code}")]
 	public async Task<IActionResult> Redeem(string code)
 	{

--- a/Corkboard/Controllers/ServersController.cs
+++ b/Corkboard/Controllers/ServersController.cs
@@ -213,6 +213,15 @@ public class ServersController : BaseController
 		return RedirectToAction(nameof(Index));
 	}
 
+	/// <summary>
+	/// Displays the join page for a server, validating membership and privacy.
+	/// GET /Servers/{serverId}/Join and /Servers/Join
+	/// </summary>
+	/// <param name="serverId">Optional server ID to join; if <c>null</c>, shows generic join page.</param>
+	/// <returns>
+	/// The join view when allowed, redirects if already a member, or <see cref="NotFound()"/> when server is missing.
+	/// Sets <c>TempData</c> messages for membership or privacy constraints.
+	/// </returns>
 	[HttpGet("Servers/{serverId}/Join")]
 	[HttpGet("Servers/Join")]
 	public async Task<IActionResult> Join(int? serverId)
@@ -245,6 +254,15 @@ public class ServersController : BaseController
 		return View(server);
 	}
 
+	/// <summary>
+	/// Handles joining a public server for the current user.
+	/// POST /Servers/{serverId}/Join
+	/// </summary>
+	/// <param name="serverId">The server ID to join.</param>
+	/// <returns>
+	/// Redirects to channels on success, back to join page for privacy issues, or <see cref="NotFound()"/> if server is missing.
+	/// Sets <c>TempData</c> messages when already a member or joining is not allowed.
+	/// </returns>
 	[HttpPost("Servers/{serverId}/Join")]
 	[ValidateAntiForgeryToken]
 	[ActionName("Join")]

--- a/Corkboard/Data/DTOs/MessageDto.cs
+++ b/Corkboard/Data/DTOs/MessageDto.cs
@@ -1,23 +1,23 @@
 namespace Corkboard.Data.DTOs;
 
 /// <summary>
-/// Data Transfer Object representing a message returned by the API.
-/// Contains only the fields required by clients to display a message.
+/// Data Transfer Object representing a message for client consumption.
+/// Includes only the fields required to render chat items.
 /// </summary>
 public class MessageDto
 {
 	/// <summary>
-	/// The message ID.
+	/// Unique identifier of the message.
 	/// </summary>
 	public int Id { get; set; }
 
 	/// <summary>
-	/// The textual content of the message.
+	/// Text content of the message.
 	/// </summary>
 	public string Text { get; set; } = null!;
 
 	/// <summary>
-	/// The sender's username.
+	/// Username of the message sender.
 	/// </summary>
 	public string SenderUsername { get; set; } = null!;
 

--- a/Corkboard/Models/ServerInvite.cs
+++ b/Corkboard/Models/ServerInvite.cs
@@ -86,6 +86,11 @@ public class ServerInvite : IValidatableObject
 	/// </summary>
 	public List<ServerMember> CreatedMemberships { get; set; } = new List<ServerMember>();
 
+	/// <summary>
+	/// Validates business rules for invites, such as expiry and single-use constraints.
+	/// </summary>
+	/// <param name="validationContext">The validation context.</param>
+	/// <returns>An enumeration of validation errors; empty when valid.</returns>
 	public IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
 	{
 		if (InvitedUserId != null && !OneTimeUse)

--- a/Corkboard/Models/ViewModels/HomeController/ErrorViewModel.cs
+++ b/Corkboard/Models/ViewModels/HomeController/ErrorViewModel.cs
@@ -1,7 +1,17 @@
 namespace Corkboard.Models.ViewModels.HomeController;
 
+/// <summary>
+/// View model for displaying error information, including the current request ID.
+/// </summary>
 public class ErrorViewModel
 {
+    /// <summary>
+    /// The ID of the current request for tracing and diagnostics.
+    /// </summary>
     public string? RequestId { get; set; }
+
+    /// <summary>
+    /// Indicates whether a non-empty <see cref="RequestId"/> is available.
+    /// </summary>
     public bool ShowRequestId => !string.IsNullOrEmpty(RequestId);
 }

--- a/Corkboard/Models/ViewModels/ServersController/ChannelViewModel.cs
+++ b/Corkboard/Models/ViewModels/ServersController/ChannelViewModel.cs
@@ -2,10 +2,19 @@ using System.ComponentModel.DataAnnotations.Schema;
 
 namespace Corkboard.Models.ViewModels.ServersController;
 
+/// <summary>
+/// Lightweight view model representing a channel for listing and selection.
+/// </summary>
 [NotMapped]
 public class ChannelViewModel
 {
+    /// <summary>
+    /// Channel identifier.
+    /// </summary>
     public int Id { get; set; }
 
+    /// <summary>
+    /// Display name of the channel.
+    /// </summary>
     public string Name { get; set; } = string.Empty;
 }

--- a/Corkboard/Models/ViewModels/ServersController/ChatPartialModel.cs
+++ b/Corkboard/Models/ViewModels/ServersController/ChatPartialModel.cs
@@ -3,10 +3,24 @@ using System.ComponentModel.DataAnnotations.Schema;
 
 namespace Corkboard.Models.ViewModels.ServersController;
 
+/// <summary>
+/// View model for rendering a chat partial with messages for a specific server/channel.
+/// </summary>
 [NotMapped]
 public class ChatPartialModel
 {
+    /// <summary>
+    /// The server identifier.
+    /// </summary>
     public int ServerId { get; set; }
+
+    /// <summary>
+    /// The channel identifier.
+    /// </summary>
     public int ChannelId { get; set; }
+
+    /// <summary>
+    /// The messages to display within the chat partial.
+    /// </summary>
     public List<MessageDto> Messages { get; set; } = new();
 }

--- a/Corkboard/Models/ViewModels/ServersController/ServerChannelsViewModel.cs
+++ b/Corkboard/Models/ViewModels/ServersController/ServerChannelsViewModel.cs
@@ -3,18 +3,39 @@ using System.ComponentModel.DataAnnotations.Schema;
 
 namespace Corkboard.Models.ViewModels.ServersController;
 
+/// <summary>
+/// View model for the server channels page, including navigation and current messages.
+/// </summary>
 [NotMapped]
 public class ServerChannelsViewModel
 {
+    /// <summary>
+    /// The current server identifier.
+    /// </summary>
     public int ServerId { get; set; }
 
+    /// <summary>
+    /// The currently selected channel identifier, if any.
+    /// </summary>
     public int? SelectedChannelId { get; set; }
 
+    /// <summary>
+    /// The display name of the current server.
+    /// </summary>
     public string ServerName { get; set; } = string.Empty;
 
+    /// <summary>
+    /// List of channels available within the server.
+    /// </summary>
     public List<ChannelViewModel> Channels { get; set; } = new();
 
+    /// <summary>
+    /// List of servers the current user belongs to for quick navigation.
+    /// </summary>
     public List<ServerListItemViewModel> UserServers { get; set; } = new();
 
+    /// <summary>
+    /// The messages for the selected channel.
+    /// </summary>
     public List<MessageDto> Messages { get; set; } = new();
 }

--- a/Corkboard/Models/ViewModels/ServersController/ServerListItemViewModel.cs
+++ b/Corkboard/Models/ViewModels/ServersController/ServerListItemViewModel.cs
@@ -2,12 +2,24 @@ using System.ComponentModel.DataAnnotations.Schema;
 
 namespace Corkboard.Models.ViewModels.ServersController;
 
+/// <summary>
+/// Lightweight view model representing a server in a sidebar list.
+/// </summary>
 [NotMapped]
 public class ServerListItemViewModel
 {
+    /// <summary>
+    /// Server identifier.
+    /// </summary>
     public int Id { get; set; }
 
+    /// <summary>
+    /// Display name of the server.
+    /// </summary>
     public string Name { get; set; } = string.Empty;
 
+    /// <summary>
+    /// Optional URL to the server icon.
+    /// </summary>
     public string? IconUrl { get; set; }
 }


### PR DESCRIPTION
Closes #48 

This pull request focuses on improving code documentation across several controllers, models, and view models. The main changes involve adding or enhancing XML documentation comments to clarify the purpose, usage, and return values of methods and data structures. These improvements will help future developers understand the intent and behavior of the code more easily.

**Controller method documentation improvements:**

* Added detailed XML documentation for user role and server membership helper methods in `BaseController`, clarifying their purpose and return values. [[1]](diffhunk://#diff-e94943d6344897b335c5229b00cec4c6fe93f8286f6ceb9e68d6a0601deab237R36-R43) [[2]](diffhunk://#diff-e94943d6344897b335c5229b00cec4c6fe93f8286f6ceb9e68d6a0601deab237R53-R68)
* Added or expanded XML documentation for invite redemption and server join endpoints in `InvitesController` and `ServersController`, describing route behavior, parameters, and expected outcomes. [[1]](diffhunk://#diff-eb0ccd28e4b1eb5b947c74a6ebb60381cdef76c5cf8cd8fef2896cb9c5ef83c1R49-R57) [[2]](diffhunk://#diff-4fb7d37ccd683f68606484fb14119531161ecd412d0970080e18b85aa11f7722R216-R224) [[3]](diffhunk://#diff-4fb7d37ccd683f68606484fb14119531161ecd412d0970080e18b85aa11f7722R257-R265)

**Model and DTO documentation:**

* Improved and clarified XML comments in `MessageDto` to better describe its fields and purpose for client consumption.
* Added XML documentation to the `Validate` method in `ServerInvite` to explain its business rule validation logic.

**View model documentation:**

* Added or expanded XML documentation for various view models, including `ErrorViewModel`, `ChannelViewModel`, `ChatPartialModel`, `ServerChannelsViewModel`, and `ServerListItemViewModel`, to clarify their structure and intended use in the UI. [[1]](diffhunk://#diff-059272cfe10ece2550d3fcae2652c6eaaf5ff64643d706fe5009ea7248bd3f91R3-R15) [[2]](diffhunk://#diff-7a9350856a097958f9779bde05818285bcb0287753a5168a0218f10a1d13bf6eR5-R18) [[3]](diffhunk://#diff-21ec92e6b23118afdad01af285d6708937400294b3a8544e411116b63c769b77R6-R24) [[4]](diffhunk://#diff-627756a939b7bcf18a597cbad3ba92f9e4159f039aa490bd320e1df6a1c155e2R6-R39) [[5]](diffhunk://#diff-2c9c2de54441dd00929ba37cda930557a758f961d1103d7abb144b96ba942deeR5-R23)